### PR TITLE
Fix accumulation of exact-match glossary candidates

### DIFF
--- a/sutysisku.el
+++ b/sutysisku.el
@@ -110,7 +110,7 @@
                     (setf exact (append (list item) exact)))
 
                    ((s-equals? str gloss)
-                    (setf gloss-exact (append (list item) exact)))
+                    (setf gloss-exact (append (list item) gloss-exact)))
 
                    ((s-prefix? str word)
                     (setf word-prefix (append (list item) word-prefix)))


### PR DESCRIPTION
Fix an error in the `sutysisku--candidates` function that caused it to update the list of exactly matching glossary entries using the current list of exactly matching words.

* `sutysisku.el` (`sutysisku--candidates`): Fix accumulation of `gloss-exact`.